### PR TITLE
Add dependabot ecosystem for Dockerfile

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,3 +13,9 @@ updates:
       - "kind/dependabot"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/Dockerfile"
+    labels:
+      - "kind/dependabot"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
To detect OpenSuse leap and golang BCI updates